### PR TITLE
fixup upstream merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - '*'
   pull_request:
     branches:
       - main
@@ -15,14 +13,12 @@ on:
 jobs:
   build-linux:
     name: Linux
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v2
       with:
-        node-version: '12.x'
-    - name: Install dependencies
-      run: sudo apt-get install libx11-dev zlib1g-dev libpng-dev libxtst-dev
+        node-version: '16'
     - name: Build it
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -31,17 +27,12 @@ jobs:
         npm run dist
   build-mac:
     name: macOS
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v2
       with:
-        node-version: '12.x'
-    - name: Fixup Xcode
-      # https://github.com/actions/virtual-environments/issues/2557
-      run: |
-        sudo xcode-select -s "/Applications/Xcode_12.4.app"
-        sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
+        node-version: '16'
     - name: Prepare for app signing and notarization
       if: ${{ github.event_name != 'pull_request' }}
       run: |
@@ -63,9 +54,9 @@ jobs:
     runs-on: windows-2019
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v2
       with:
-        node-version: '12.x'
+        node-version: '16'
     - name: Build it
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,7 @@
 {
   "name": "jitsi-meet-electron",
-<<<<<<< HEAD
   "version": "2021.11.2",
   "lockfileVersion": 2,
-=======
-  "version": "2.8.12",
-  "lockfileVersion": 1,
->>>>>>> main
   "requires": true,
   "packages": {
     "": {
@@ -47,6 +42,7 @@
         "css-loader": "3.5.0",
         "electron": "13.5.2",
         "electron-builder": "22.11.11",
+        "electron-builder-notarize": "^1.2.0",
         "electron-context-menu": "^2.5.0",
         "electron-is-dev": "^1.2.0",
         "electron-log": "^4.3.2",
@@ -6102,6 +6098,12 @@
       "integrity": "sha512-1Ciqv9pqwVtW6FsIUKSZNB82E5Cu1I2bBTj1xuIHXLe/1zYLl3956Nbhg2MzSYHVfl9/rmanjbQIb7LibfCnug==",
       "dev": true
     },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "dev": true
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -9637,6 +9639,147 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/electron-builder-notarize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/electron-builder-notarize/-/electron-builder-notarize-1.2.0.tgz",
+      "integrity": "sha512-mSU5CSjydNlO5oFSOimJvzKQ4m/whUUBoE3i2xSAOF7+T2ZIzSfsGCT1SJvqsiHYf2xvTb2RpFoHWE6Oc9Cvgg==",
+      "dev": true,
+      "dependencies": {
+        "electron-notarize": "^0.2.0",
+        "js-yaml": "^3.14.0",
+        "read-pkg-up": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "electron-builder": ">= 20.44.4"
+      }
+    },
+    "node_modules/electron-builder-notarize/node_modules/electron-notarize": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-0.2.1.tgz",
+      "integrity": "sha512-oZ6/NhKeXmEKNROiFmRNfytqu3cxqC95sjooG7kBXQVEUSQkZnbiAhxVh5jXngL881G197pbwpeVPJyM7Ikmxw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^8.1.0"
+      }
+    },
+    "node_modules/electron-builder-notarize/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-builder-notarize/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-builder-notarize/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-builder-notarize/node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/electron-builder-notarize/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-builder-notarize/node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-builder-notarize/node_modules/read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/electron-builder-notarize/node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-builder-notarize/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/electron-builder/node_modules/ansi-regex": {
@@ -13263,6 +13406,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
     "node_modules/json-schema-traverse": {
@@ -18608,26 +18757,34 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -18635,13 +18792,17 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -18649,57 +18810,75 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.4",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/debug": {
       "version": "3.2.6",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -18709,21 +18888,27 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.7",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^2.6.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -18737,8 +18922,10 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/glob": {
       "version": "7.1.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -18756,13 +18943,17 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -18772,16 +18963,20 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minimatch": "^3.0.4"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -18789,21 +18984,27 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.4",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -18813,13 +19014,17 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -18829,13 +19034,17 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/minimist": {
       "version": "1.2.5",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/minipass": {
       "version": "2.9.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -18843,8 +19052,10 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/minizlib": {
       "version": "1.3.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minipass": "^2.9.0"
       }
@@ -18852,8 +19063,10 @@
     "node_modules/watchpack/node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.3",
       "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -18863,13 +19076,17 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/ms": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/needle": {
       "version": "2.3.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -18884,8 +19101,10 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.14.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
@@ -18904,8 +19123,10 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "abbrev": "1",
         "osenv": "^0.1.4"
@@ -18916,21 +19137,27 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.4.8",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1",
@@ -18939,8 +19166,10 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -18950,48 +19179,60 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -18999,21 +19240,27 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
+      "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -19026,8 +19273,10 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.7",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -19040,8 +19289,10 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/rimraf": {
       "version": "2.7.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -19051,49 +19302,65 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/semver": {
       "version": "5.7.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -19105,8 +19372,10 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -19116,16 +19385,20 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/tar": {
       "version": "4.4.13",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
@@ -19141,26 +19414,34 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/yallist": {
       "version": "3.1.1",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/watchpack/node_modules/glob-parent": {
       "version": "3.1.0",
@@ -24980,9 +25261,9 @@
       "dev": true
     },
     "@types/normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
     "@types/parse-json": {
@@ -26553,9 +26834,9 @@
       },
       "dependencies": {
         "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
@@ -26626,18 +26907,18 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
-      "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.2.1.tgz",
+      "integrity": "sha512-/j5PPkb5Feyps9e+jo07jUZGvkB5Aj953NrI4s8xSVScrAo/RHeILrtdb4uzR7N6aaFFxxJ+gt8mA8HfNpw76w==",
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
+        "fsevents": "~2.1.0",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.3.0"
+        "readdirp": "~3.1.3"
       }
     },
     "chownr": {
@@ -28101,14 +28382,9 @@
           }
         },
         "yargs-parser": {
-<<<<<<< HEAD
           "version": "20.2.9",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
           "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-=======
-          "version": "20.2.5",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.5.tgz",
-          "integrity": "sha512-jYRGS3zWy20NtDtK2kBgo/TlAoy5YUuhD9/LZ7z7W4j1Fdw2cqD0xEEclf8fxc8xjD6X5Qr+qQQwCEsP8iRiYg==",
           "dev": true
         }
       }
@@ -28124,6 +28400,16 @@
         "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
+        "electron-notarize": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-0.2.1.tgz",
+          "integrity": "sha512-oZ6/NhKeXmEKNROiFmRNfytqu3cxqC95sjooG7kBXQVEUSQkZnbiAhxVh5jXngL881G197pbwpeVPJyM7Ikmxw==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "fs-extra": "^8.1.0"
+          }
+        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -28132,16 +28418,6 @@
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
-          }
-        },
-        "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
           }
         },
         "locate-path": {
@@ -28215,15 +28491,14 @@
           "version": "0.8.1",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
           "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
->>>>>>> main
           "dev": true
         }
       }
     },
     "electron-context-menu": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/electron-context-menu/-/electron-context-menu-2.5.2.tgz",
-      "integrity": "sha512-1cEQR6fA9ktFsRBc+eXPwvrOgAPytUD7rUV4iBAA5zTrLAPKokJ23xeMjcK2fjrDPrlFRBxcLz0KP+GUhMrSCQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/electron-context-menu/-/electron-context-menu-2.5.0.tgz",
+      "integrity": "sha512-kzvp8XUmbp2TG2hELJUl7Yjlq4Ag549JQu/C8mxvy1CmAU15UFmPC3bPdXMGE/e3xbi97shgxfttxeQ/6h4MoQ==",
       "dev": true,
       "requires": {
         "cli-truncate": "^2.1.0",
@@ -28273,9 +28548,9 @@
       }
     },
     "electron-log": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.4.1.tgz",
-      "integrity": "sha512-nK/DwxPLtwWbggPCm27eMQhYHc3gzoZ+cokBK99diO4WsZJKrv5l44EUW8mRfWpmC8ZubnMyp6GTUIJyTc9AJA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.3.2.tgz",
+      "integrity": "sha512-PJPWE8JDzQ137UlxX9K917nI8GTcwgiJpE2PMPXZo+I6C4AaZU+JWQ3lW5NjQ1Lg8Qk8qbze+Ly0yAiqhbmpeA==",
       "dev": true
     },
     "electron-notarize": {
@@ -28406,15 +28681,6 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
-        },
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
         },
         "fs-extra": {
           "version": "10.0.0",
@@ -28586,18 +28852,6 @@
         }
       }
     },
-<<<<<<< HEAD
-=======
-    "electron-util": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/electron-util/-/electron-util-0.13.1.tgz",
-      "integrity": "sha512-CvOuAyQPaPtnDp7SspwnT1yTb1yynw6yp4LrZCfEJ7TG/kJFiZW9RqMHlCEFWMn3QNoMkNhGVeCvWJV5NsYyuQ==",
-      "requires": {
-        "electron-is-dev": "^1.1.0",
-        "new-github-issue-url": "^0.2.1"
-      }
-    },
->>>>>>> main
     "electron-window-state": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/electron-window-state/-/electron-window-state-5.0.3.tgz",
@@ -28670,9 +28924,9 @@
       },
       "dependencies": {
         "iconv-lite": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
           "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -29070,75 +29324,11 @@
             "isarray": "^1.0.0"
           }
         },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^2.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^2.0.0"
-          }
         }
       }
     },
@@ -29666,13 +29856,19 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
         }
       }
     },
@@ -29868,9 +30064,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.0.tgz",
+      "integrity": "sha512-+iXhW3LuDQsno8dOIrCIT/CBjeBWuP7PXe8w9shnj9Lebny/Gx1ZjVBYwexLz36Ri2jKuXMNpV6CYNh8lHHgrQ==",
       "optional": true
     },
     "function-bind": {
@@ -30098,9 +30294,9 @@
       "dev": true
     },
     "globalthis": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.1.tgz",
-      "integrity": "sha512-mJPRTc/P39NH/iNG4mXa9aIhNymaQikTrnspeCa2ZuJ+mH2QN/rXwtX3XwKrHqWgUQFbNZKtHM105aHzJalElw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.2.tgz",
+      "integrity": "sha512-ZQnSFO1la8P7auIOQECnm0sSuoMeaSq0EEdXMBFF2QJO4uNcwbyhSgG3MruWNbFTqCLmxVwGOl7LZ9kASvHdeQ==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -30343,13 +30539,13 @@
         "terser": "^4.6.3"
       }
     },
-    "html-parse-stringify": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
-      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+    "html-parse-stringify2": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify2/-/html-parse-stringify2-2.0.1.tgz",
+      "integrity": "sha1-3FZwtyksoVi3vJFsmmc1rIhyg0o=",
       "dev": true,
       "requires": {
-        "void-elements": "3.1.0"
+        "void-elements": "^2.0.1"
       }
     },
     "html-webpack-plugin": {
@@ -30424,13 +30620,19 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
         }
       }
     },
@@ -30613,9 +30815,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
+      "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ=="
     },
     "inquirer": {
       "version": "6.5.2",
@@ -30986,20 +31188,6 @@
         "whatwg-fetch": ">=0.10.0"
       }
     },
-<<<<<<< HEAD
-=======
-    "istextorbinary": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-5.12.0.tgz",
-      "integrity": "sha512-wLDRWD7qpNTYubk04+q3en1+XZGS4vYWK0+SxNSXJLaITMMEK+J3o/TlOMyULeH1qozVZ9uUkKcyMA8odyxz8w==",
-      "dev": true,
-      "requires": {
-        "binaryextensions": "^4.15.0",
-        "editions": "^6.1.0",
-        "textextensions": "^5.11.0"
-      }
-    },
->>>>>>> main
     "jake": {
       "version": "10.8.2",
       "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
@@ -31010,21 +31198,6 @@
         "chalk": "^2.4.2",
         "filelist": "^1.0.1",
         "minimatch": "^3.0.4"
-<<<<<<< HEAD
-=======
-      }
-    },
-    "jitsi-meet-electron-utils": {
-      "version": "github:jitsi/jitsi-meet-electron-utils#92298631f52bf5465a0266307b1f608753584eb4",
-      "from": "github:jitsi/jitsi-meet-electron-utils#v2.0.22",
-      "requires": {
-        "jitsi-meet-logger": "github:jitsi/jitsi-meet-logger#v1.0.0",
-        "mac-screen-capture-permissions": "^2.0.0",
-        "nan": "^2.14.2",
-        "postis": "^2.2.0",
-        "prebuild-install": "^5.3.0",
-        "robotjs": "0.6.0"
->>>>>>> main
       }
     },
     "jitsi-meet-logger": {
@@ -31374,136 +31547,6 @@
         "yallist": "^3.0.2"
       }
     },
-<<<<<<< HEAD
-=======
-    "mac-screen-capture-permissions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mac-screen-capture-permissions/-/mac-screen-capture-permissions-2.0.0.tgz",
-      "integrity": "sha512-f70KKpx5WhD8mmrAwLeeee31EfSM4p1K7kBBNBVXyfWE7ZQTIbbAF2PxJ0bMsDxyyeX5roBcH+qJYlSTANtCOA==",
-      "requires": {
-        "electron-util": "^0.13.0",
-        "execa": "^2.0.4",
-        "macos-version": "^5.2.1",
-        "prebuild-install": "^6.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          }
-        },
-        "execa": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
-          "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^3.0.0",
-            "onetime": "^5.1.0",
-            "p-finally": "^2.0.0",
-            "signal-exit": "^3.0.2",
-            "strip-final-newline": "^2.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "is-stream": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
-        },
-        "npm-run-path": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
-          "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
-          "requires": {
-            "path-key": "^3.0.0"
-          }
-        },
-        "onetime": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-          "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-          "requires": {
-            "mimic-fn": "^2.1.0"
-          }
-        },
-        "p-finally": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw=="
-        },
-        "path-key": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
-        },
-        "prebuild-install": {
-          "version": "6.1.4",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
-          "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
-          "requires": {
-            "detect-libc": "^1.0.3",
-            "expand-template": "^2.0.3",
-            "github-from-package": "0.0.0",
-            "minimist": "^1.2.3",
-            "mkdirp-classic": "^0.5.3",
-            "napi-build-utils": "^1.0.1",
-            "node-abi": "^2.21.0",
-            "npmlog": "^4.0.1",
-            "pump": "^3.0.0",
-            "rc": "^1.2.7",
-            "simple-get": "^3.0.3",
-            "tar-fs": "^2.0.0",
-            "tunnel-agent": "^0.6.0"
-          }
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
-      }
-    },
-    "macos-version": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/macos-version/-/macos-version-5.2.1.tgz",
-      "integrity": "sha512-OHJU8nTNxHYL1FQhD+nZawWgXKXAqDGr4kluLtaqKO4au3cR41y1mKuVShOU5U4rOYiuPanljq6oFGmV2B9DFA==",
-      "requires": {
-        "semver": "^5.6.0"
-      }
-    },
->>>>>>> main
     "make-dir": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
@@ -31630,14 +31673,6 @@
         }
       }
     },
-<<<<<<< HEAD
-=======
-    "merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
-    },
->>>>>>> main
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -31760,9 +31795,9 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
-      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
       "dev": true
     },
     "mimic-fn": {
@@ -31958,14 +31993,6 @@
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
-<<<<<<< HEAD
-=======
-    "new-github-issue-url": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/new-github-issue-url/-/new-github-issue-url-0.2.1.tgz",
-      "integrity": "sha512-md4cGoxuT4T4d/HDOXbrUHkTKrp/vp+m3aOA7XXVYwNsUNMK49g3SQicTSeV5GIz/5QVGAeYRAOlyp9OvlgsYA=="
-    },
->>>>>>> main
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -31983,15 +32010,9 @@
       }
     },
     "node-abi": {
-<<<<<<< HEAD
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.5.0.tgz",
       "integrity": "sha512-LtHvNIBgOy5mO8mPEUtkCW/YCRWYEKshIvqhe1GHHyXEHEB5mgICyYnAcl4qan3uFeRROErKGzatFHPf6kDxWw==",
-=======
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
-      "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
->>>>>>> main
       "requires": {
         "semver": "^7.3.5"
       },
@@ -32639,9 +32660,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
+      "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA=="
     },
     "pify": {
       "version": "4.0.1",
@@ -32803,15 +32824,9 @@
       "integrity": "sha1-3F4yN2WYXd/cv9r8MUGpVprvdak="
     },
     "prebuild-install": {
-<<<<<<< HEAD
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.0.0.tgz",
       "integrity": "sha512-IvSenf33K7JcgddNz2D5w521EgO+4aMMjFt73Uk9FRzQ7P+QZPKrp7qPsDydsSwjGt3T5xRNnM1bj1zMTD5fTA==",
-=======
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
-      "integrity": "sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==",
->>>>>>> main
       "requires": {
         "detect-libc": "^1.0.3",
         "expand-template": "^2.0.3",
@@ -33024,6 +33039,13 @@
         "ini": "~1.3.0",
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        }
       }
     },
     "react": {
@@ -33063,13 +33085,19 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
         }
       }
     },
@@ -33108,23 +33136,29 @@
       }
     },
     "react-i18next": {
-      "version": "11.11.4",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.11.4.tgz",
-      "integrity": "sha512-ayWFlu8Sc7GAxW1PzMaPtzq+yiozWMxs0P1WeITNVzXAVRhC0Httkzw/IiODBta6seJRBCLrtUeFUSXhAIxlRg==",
+      "version": "11.8.12",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.8.12.tgz",
+      "integrity": "sha512-M2PSVP9MzT/7yofXfCOF5gAVotinrM4BXWiguk8uFSznJsfFzTjrp3K9CBWcXitpoCBVZGZJ2AnbaWGSNkJqfw==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.14.5",
-        "html-parse-stringify": "^3.0.1"
+        "@babel/runtime": "^7.13.6",
+        "html-parse-stringify2": "^2.0.1"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
         }
       }
     },
@@ -33306,6 +33340,72 @@
         }
       }
     },
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        }
+      }
+    },
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
@@ -33321,20 +33421,21 @@
       }
     },
     "readdirp": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
-      "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.1.3.tgz",
+      "integrity": "sha512-ZOsfTGkjO2kqeR5Mzr5RYDbTGYneSkdNKX2fOX2P5jF7vMrd/GNnIAUtDldeHHumHUCQ3V05YfWUdxMPAsRu9Q==",
       "requires": {
-        "picomatch": "^2.0.7"
+        "picomatch": "^2.0.4"
       }
     },
     "redux": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.1.tgz",
-      "integrity": "sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
+      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.9.2"
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
       }
     },
     "redux-logger": {
@@ -33674,19 +33775,6 @@
         }
       }
     },
-<<<<<<< HEAD
-=======
-    "robotjs": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/robotjs/-/robotjs-0.6.0.tgz",
-      "integrity": "sha512-6pRWI3d+CBZqCXT/rsJfabbZoELua+jTeXilG27F8Jvix/J2BYZ0O7Tly2WCmXyqw5xYdCvOwvCeLRHEtXkt4w==",
-      "requires": {
-        "nan": "^2.14.0",
-        "node-abi": "^2.13.0",
-        "prebuild-install": "^5.3.3"
-      }
-    },
->>>>>>> main
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -34449,14 +34537,6 @@
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
-<<<<<<< HEAD
-=======
-    "strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
-    },
->>>>>>> main
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -34604,6 +34684,12 @@
           }
         }
       }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "dev": true
     },
     "table": {
       "version": "5.4.6",
@@ -35019,9 +35105,9 @@
       }
     },
     "ua-parser-js": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
+      "version": "0.7.27",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.27.tgz",
+      "integrity": "sha512-eXMaRYK2skomGocoX0x9sBXzx5A1ZVQgXfrW4mTc8dT0zS7olEcyfudAzRC5tIIRgLxQ69B6jut3DI+n5hslPA==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
@@ -35414,9 +35500,9 @@
       "dev": true
     },
     "void-elements": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
-      "integrity": "sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
       "dev": true
     },
     "warning": {
@@ -35539,19 +35625,27 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.5",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^2.0.6"
@@ -35559,11 +35653,15 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -35571,57 +35669,81 @@
             },
             "chownr": {
               "version": "1.1.4",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "debug": {
               "version": "3.2.6",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "^2.1.1"
               }
             },
             "deep-extend": {
               "version": "0.6.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "delegates": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "fs-minipass": {
               "version": "1.2.7",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "minipass": "^2.6.0"
               }
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "gauge": {
               "version": "2.7.4",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "aproba": "^1.0.3",
                 "console-control-strings": "^1.0.0",
@@ -35636,6 +35758,8 @@
             "glob": {
               "version": "7.1.6",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -35647,11 +35771,15 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "iconv-lite": {
               "version": "0.4.24",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
               }
@@ -35659,6 +35787,8 @@
             "ignore-walk": {
               "version": "3.0.3",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "minimatch": "^3.0.4"
               }
@@ -35666,6 +35796,8 @@
             "inflight": {
               "version": "1.0.6",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -35673,11 +35805,9 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true
-            },
-            "ini": {
-              "version": "1.3.5",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -35688,28 +35818,38 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "1.2.5",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -35718,6 +35858,8 @@
             "minizlib": {
               "version": "1.3.3",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "minipass": "^2.9.0"
               }
@@ -35725,17 +35867,23 @@
             "mkdirp": {
               "version": "0.5.3",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
             },
             "ms": {
               "version": "2.1.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "needle": {
               "version": "2.3.3",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "debug": "^3.2.6",
                 "iconv-lite": "^0.4.4",
@@ -35745,6 +35893,8 @@
             "node-pre-gyp": {
               "version": "0.14.0",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "detect-libc": "^1.0.2",
                 "mkdirp": "^0.5.1",
@@ -35761,6 +35911,8 @@
             "nopt": {
               "version": "4.0.3",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "abbrev": "1",
                 "osenv": "^0.1.4"
@@ -35769,17 +35921,23 @@
             "npm-bundled": {
               "version": "1.1.1",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "npm-normalize-package-bin": "^1.0.1"
               }
             },
             "npm-normalize-package-bin": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "npm-packlist": {
               "version": "1.4.8",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "ignore-walk": "^3.0.1",
                 "npm-bundled": "^1.0.1",
@@ -35789,6 +35947,8 @@
             "npmlog": {
               "version": "4.1.2",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "are-we-there-yet": "~1.1.2",
                 "console-control-strings": "~1.1.0",
@@ -35798,30 +35958,42 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
             },
             "os-homedir": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "osenv": {
               "version": "0.1.5",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "os-homedir": "^1.0.0",
                 "os-tmpdir": "^1.0.0"
@@ -35829,15 +36001,21 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "process-nextick-args": {
               "version": "2.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "rc": {
               "version": "1.2.8",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -35848,6 +36026,8 @@
             "readable-stream": {
               "version": "2.3.7",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -35861,37 +36041,53 @@
             "rimraf": {
               "version": "2.7.1",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "glob": "^7.1.3"
               }
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "sax": {
               "version": "1.2.4",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "semver": {
               "version": "5.7.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -35899,6 +36095,8 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -35908,17 +36106,23 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "tar": {
               "version": "4.4.13",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "chownr": "^1.1.1",
                 "fs-minipass": "^1.2.5",
@@ -35931,22 +36135,30 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "wide-align": {
               "version": "1.1.3",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "string-width": "^1.0.2 || 2"
               }
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "productName": "FreifunkMeet",
     "generateUpdatesFilesForAllChannels": true,
     "afterPack": "./linux-sandbox-fix.js",
-    "afterSign": "./notarize.js",
+    "afterSign": "electron-builder-notarize",
     "files": [
       "build",
       "resources",
@@ -159,6 +159,7 @@
     "css-loader": "3.5.0",
     "electron": "13.5.2",
     "electron-builder": "22.11.11",
+    "electron-builder-notarize": "^1.2.0",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",
     "electron-log": "^4.3.2",


### PR DESCRIPTION
Continue to use electron-builder-notarize instead of upstream to keep the current credentials and secrets supported.