### PR TITLE
disable prebuilds to fix mac build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '16'
+    - name: Install dependencies
+      run: sudo apt-get install libx11-dev zlib1g-dev libpng-dev libxtst-dev
     - name: Build it
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -72,6 +74,10 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '16'
+    - name: latest node-gyp for robotjs
+      run: |
+        npm install --global node-gyp@8.4.0
+        npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
     - name: Build it
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
         echo '${{ secrets.api_key }}' > ~/private_keys/AuthKey_${{ secrets.api_key_id }}.p8
         echo "CSC_LINK=${{ secrets.mac_certs }}" >> $GITHUB_ENV
         echo "CSC_KEY_PASSWORD=${{ secrets.mac_certs_password }}" >> $GITHUB_ENV
+        echo "API_KEY_FILE=~/private_keys/AuthKey_${{ secrets.api_key_id }}.p8" >> $GITHUB_ENV
         echo "API_KEY_ID=${{ secrets.api_key_id }}" >> $GITHUB_ENV
         echo "API_KEY_ISSUER_ID=${{ secrets.api_key_issuer_id }}" >> $GITHUB_ENV
     - name: Build it

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,13 @@ jobs:
       run: |
         npm install
         npm run dist
+    - uses: actions/upload-artifact@v2
+      with:
+        name: linux-binaries
+        path: |
+          dist/jitsi-meet-amd64.deb
+          dist/jitsi-meet-x86_64.AppImage
+          dist/latest-linux.yml
   build-mac:
     name: macOS
     runs-on: macos-11
@@ -49,6 +56,13 @@ jobs:
         npm install
         npm run lint
         npm run dist
+    - uses: actions/upload-artifact@v2
+      with:
+        name: mac-binaries
+        path: |
+          dist/jitsi-meet.dmg
+          dist/jitsi-meet.zip
+          dist/latest-mac.yml
   build-windows:
     name: Windows
     runs-on: windows-2019
@@ -63,3 +77,9 @@ jobs:
       run: |
         npm install
         npm run dist
+    - uses: actions/upload-artifact@v2
+      with:
+        name: windows-binaries
+        path: |
+          dist/jitsi-meet.exe
+          dist/latest.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
       with:
         name: linux-binaries
         path: |
-          dist/jitsi-meet-amd64.deb
-          dist/jitsi-meet-x86_64.AppImage
+          dist/ffmuc-meet-amd64.deb
+          dist/ffmuc-meet-x86_64.AppImage
           dist/latest-linux.yml
   build-mac:
     name: macOS
@@ -61,8 +61,8 @@ jobs:
       with:
         name: mac-binaries
         path: |
-          dist/jitsi-meet.dmg
-          dist/jitsi-meet.zip
+          dist/ffmuc-meet.dmg
+          dist/ffmuc-meet.zip
           dist/latest-mac.yml
   build-windows:
     name: Windows
@@ -82,5 +82,5 @@ jobs:
       with:
         name: windows-binaries
         path: |
-          dist/jitsi-meet.exe
+          dist/ffmuc-meet.exe
           dist/latest.yml

--- a/notarize.js
+++ b/notarize.js
@@ -9,20 +9,34 @@ exports.default = async function notarizing(context) {
         return;
     }
 
-    if (!(process.env.APPLE_ID && process.env.APPLE_ID_PASSWORD && process.env.TEAM_ID)) {
-        console.log('Skipping notarization');
-
-        return;
-    }
-
     const appName = context.packager.appInfo.productFilename;
+    const appPath = `${appOutDir}/${appName}.app`;
 
-    return await notarize({
-        tool: 'notarytool',
-        appBundleId: pkgJson.build.appId,
-        appPath: `${appOutDir}/${appName}.app`,
-        appleId: process.env.APPLE_ID,
-        appleIdPassword: process.env.APPLE_ID_PASSWORD,
-        teamId: process.env.TEAM_ID
-    });
+    if (process.env.APPLE_ID && process.env.APPLE_ID_PASSWORD && process.env.TEAM_ID) {
+        console.log(`Notarizing ${appPath} with user & password`);
+
+        return await notarize({
+            tool: 'notarytool',
+            appBundleId: pkgJson.build.appId,
+            appPath,
+            appleId: process.env.APPLE_ID,
+            appleIdPassword: process.env.APPLE_ID_PASSWORD,
+            teamId: process.env.TEAM_ID
+        });
+    } else if (process.env.API_KEY_FILE && process.env.API_KEY_ID && process.env.API_KEY_ISSUER_ID) {
+        console.log(`Notarizing ${appPath} with API key`);
+
+        return await notarize({
+            tool: 'notarytool',
+            appBundleId: pkgJson.build.appId,
+            appPath,
+            appleApiKey: process.env.API_KEY_FILE,
+            appleApiKeyId: process.env.API_KEY_ID,
+            appleApiIssuer: process.env.API_KEY_ISSUER_ID
+        });
+    }
+    console.log('Skipping notarization');
+
+    return;
+
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "css-loader": "3.5.0",
         "electron": "13.5.2",
         "electron-builder": "22.11.11",
-        "electron-builder-notarize": "^1.2.0",
         "electron-context-menu": "^2.5.0",
         "electron-is-dev": "^1.2.0",
         "electron-log": "^4.3.2",
@@ -6098,12 +6097,6 @@
       "integrity": "sha512-1Ciqv9pqwVtW6FsIUKSZNB82E5Cu1I2bBTj1xuIHXLe/1zYLl3956Nbhg2MzSYHVfl9/rmanjbQIb7LibfCnug==",
       "dev": true
     },
-    "node_modules/@types/normalize-package-data": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
-      "dev": true
-    },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -9639,147 +9632,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/electron-builder-notarize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/electron-builder-notarize/-/electron-builder-notarize-1.2.0.tgz",
-      "integrity": "sha512-mSU5CSjydNlO5oFSOimJvzKQ4m/whUUBoE3i2xSAOF7+T2ZIzSfsGCT1SJvqsiHYf2xvTb2RpFoHWE6Oc9Cvgg==",
-      "dev": true,
-      "dependencies": {
-        "electron-notarize": "^0.2.0",
-        "js-yaml": "^3.14.0",
-        "read-pkg-up": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "electron-builder": ">= 20.44.4"
-      }
-    },
-    "node_modules/electron-builder-notarize/node_modules/electron-notarize": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-0.2.1.tgz",
-      "integrity": "sha512-oZ6/NhKeXmEKNROiFmRNfytqu3cxqC95sjooG7kBXQVEUSQkZnbiAhxVh5jXngL881G197pbwpeVPJyM7Ikmxw==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "fs-extra": "^8.1.0"
-      }
-    },
-    "node_modules/electron-builder-notarize/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/electron-builder-notarize/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/electron-builder-notarize/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/electron-builder-notarize/node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/electron-builder-notarize/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/electron-builder-notarize/node_modules/read-pkg": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-      "dev": true,
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/electron-builder-notarize/node_modules/read-pkg-up": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/electron-builder-notarize/node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/electron-builder-notarize/node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/electron-builder/node_modules/ansi-regex": {
@@ -13406,12 +13258,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-      "dev": true
-    },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
     "node_modules/json-schema-traverse": {
@@ -18757,34 +18603,26 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -18792,17 +18630,13 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -18810,75 +18644,57 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.4",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/debug": {
       "version": "3.2.6",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
-      "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -18888,27 +18704,21 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.7",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "minipass": "^2.6.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -18922,10 +18732,8 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/glob": {
       "version": "7.1.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -18943,17 +18751,13 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -18963,20 +18767,16 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "minimatch": "^3.0.4"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -18984,27 +18784,21 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -19014,17 +18808,13 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -19034,17 +18824,13 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/minimist": {
       "version": "1.2.5",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/minipass": {
       "version": "2.9.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -19052,10 +18838,8 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/minizlib": {
       "version": "1.3.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "minipass": "^2.9.0"
       }
@@ -19063,10 +18847,8 @@
     "node_modules/watchpack/node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.3",
       "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -19076,17 +18858,13 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/needle": {
       "version": "2.3.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -19101,10 +18879,8 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.14.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
@@ -19123,10 +18899,8 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "abbrev": "1",
         "osenv": "^0.1.4"
@@ -19137,27 +18911,21 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.4.8",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1",
@@ -19166,10 +18934,8 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -19179,60 +18945,48 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -19240,27 +18994,21 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
-      "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -19273,10 +19021,8 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.7",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -19289,10 +19035,8 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/rimraf": {
       "version": "2.7.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -19302,65 +19046,49 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/semver": {
       "version": "5.7.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -19372,10 +19100,8 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -19385,20 +19111,16 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/tar": {
       "version": "4.4.13",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
@@ -19414,34 +19136,26 @@
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2"
       }
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/watchpack/node_modules/fsevents/node_modules/yallist": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/watchpack/node_modules/glob-parent": {
       "version": "3.1.0",
@@ -25260,12 +24974,6 @@
       "integrity": "sha512-1Ciqv9pqwVtW6FsIUKSZNB82E5Cu1I2bBTj1xuIHXLe/1zYLl3956Nbhg2MzSYHVfl9/rmanjbQIb7LibfCnug==",
       "dev": true
     },
-    "@types/normalize-package-data": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
-      "dev": true
-    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -28389,112 +28097,6 @@
         }
       }
     },
-    "electron-builder-notarize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/electron-builder-notarize/-/electron-builder-notarize-1.2.0.tgz",
-      "integrity": "sha512-mSU5CSjydNlO5oFSOimJvzKQ4m/whUUBoE3i2xSAOF7+T2ZIzSfsGCT1SJvqsiHYf2xvTb2RpFoHWE6Oc9Cvgg==",
-      "dev": true,
-      "requires": {
-        "electron-notarize": "^0.2.0",
-        "js-yaml": "^3.14.0",
-        "read-pkg-up": "^7.0.0"
-      },
-      "dependencies": {
-        "electron-notarize": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-0.2.1.tgz",
-          "integrity": "sha512-oZ6/NhKeXmEKNROiFmRNfytqu3cxqC95sjooG7kBXQVEUSQkZnbiAhxVh5jXngL881G197pbwpeVPJyM7Ikmxw==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "fs-extra": "^8.1.0"
-          }
-        },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "parse-json": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "error-ex": "^1.3.1",
-            "json-parse-even-better-errors": "^2.3.0",
-            "lines-and-columns": "^1.1.6"
-          }
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-          "dev": true,
-          "requires": {
-            "@types/normalize-package-data": "^2.4.0",
-            "normalize-package-data": "^2.5.0",
-            "parse-json": "^5.0.0",
-            "type-fest": "^0.6.0"
-          },
-          "dependencies": {
-            "type-fest": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-              "dev": true
-            }
-          }
-        },
-        "read-pkg-up": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-          "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-          "dev": true,
-          "requires": {
-            "find-up": "^4.1.0",
-            "read-pkg": "^5.2.0",
-            "type-fest": "^0.8.1"
-          }
-        },
-        "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-          "dev": true
-        }
-      }
-    },
     "electron-context-menu": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/electron-context-menu/-/electron-context-menu-2.5.0.tgz",
@@ -31249,12 +30851,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-      "dev": true
-    },
-    "json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
     "json-schema-traverse": {
@@ -35625,27 +35221,19 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "are-we-there-yet": {
               "version": "1.1.5",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^2.0.6"
@@ -35653,15 +35241,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -35669,81 +35253,57 @@
             },
             "chownr": {
               "version": "1.1.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "debug": {
               "version": "3.2.6",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "ms": "^2.1.1"
               }
             },
             "deep-extend": {
               "version": "0.6.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "delegates": {
               "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "fs-minipass": {
               "version": "1.2.7",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "minipass": "^2.6.0"
               }
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "gauge": {
               "version": "2.7.4",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "aproba": "^1.0.3",
                 "console-control-strings": "^1.0.0",
@@ -35758,8 +35318,6 @@
             "glob": {
               "version": "7.1.6",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -35771,15 +35329,11 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "iconv-lite": {
               "version": "0.4.24",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
               }
@@ -35787,8 +35341,6 @@
             "ignore-walk": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "minimatch": "^3.0.4"
               }
@@ -35796,8 +35348,6 @@
             "inflight": {
               "version": "1.0.6",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -35805,51 +35355,37 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "1.2.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -35858,8 +35394,6 @@
             "minizlib": {
               "version": "1.3.3",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "minipass": "^2.9.0"
               }
@@ -35867,23 +35401,17 @@
             "mkdirp": {
               "version": "0.5.3",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
             },
             "ms": {
               "version": "2.1.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "needle": {
               "version": "2.3.3",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "debug": "^3.2.6",
                 "iconv-lite": "^0.4.4",
@@ -35893,8 +35421,6 @@
             "node-pre-gyp": {
               "version": "0.14.0",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "detect-libc": "^1.0.2",
                 "mkdirp": "^0.5.1",
@@ -35911,8 +35437,6 @@
             "nopt": {
               "version": "4.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "abbrev": "1",
                 "osenv": "^0.1.4"
@@ -35921,23 +35445,17 @@
             "npm-bundled": {
               "version": "1.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "npm-normalize-package-bin": "^1.0.1"
               }
             },
             "npm-normalize-package-bin": {
               "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "npm-packlist": {
               "version": "1.4.8",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "ignore-walk": "^3.0.1",
                 "npm-bundled": "^1.0.1",
@@ -35947,8 +35465,6 @@
             "npmlog": {
               "version": "4.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "are-we-there-yet": "~1.1.2",
                 "console-control-strings": "~1.1.0",
@@ -35958,42 +35474,30 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
             },
             "os-homedir": {
               "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "osenv": {
               "version": "0.1.5",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "os-homedir": "^1.0.0",
                 "os-tmpdir": "^1.0.0"
@@ -36001,21 +35505,15 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "process-nextick-args": {
               "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "rc": {
               "version": "1.2.8",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -36026,8 +35524,6 @@
             "readable-stream": {
               "version": "2.3.7",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -36041,53 +35537,37 @@
             "rimraf": {
               "version": "2.7.1",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "glob": "^7.1.3"
               }
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "sax": {
               "version": "1.2.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "semver": {
               "version": "5.7.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -36095,8 +35575,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -36106,23 +35584,17 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "tar": {
               "version": "4.4.13",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "chownr": "^1.1.1",
                 "fs-minipass": "^1.2.5",
@@ -36135,30 +35607,22 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "wide-align": {
               "version": "1.1.3",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "string-width": "^1.0.2 || 2"
               }
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "generateUpdatesFilesForAllChannels": true,
     "afterPack": "./linux-sandbox-fix.js",
     "afterSign": "./notarize.js",
+    "buildDependenciesFromSource": true,
     "files": [
       "build",
       "resources",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "productName": "FreifunkMeet",
     "generateUpdatesFilesForAllChannels": true,
     "afterPack": "./linux-sandbox-fix.js",
-    "afterSign": "electron-builder-notarize",
+    "afterSign": "./notarize.js",
     "files": [
       "build",
       "resources",
@@ -159,7 +159,6 @@
     "css-loader": "3.5.0",
     "electron": "13.5.2",
     "electron-builder": "22.11.11",
-    "electron-builder-notarize": "^1.2.0",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",
     "electron-log": "^4.3.2",


### PR DESCRIPTION
- mac: allow notarize with API key (#669)
- ci: archive binaries after build (#671)
- ci(mac): switch to upstream notarize.js
- ci: switch back to rebuilding dependencies
