### PR TITLE
Revert "ci: switch back to rebuilding dependencies"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '16'
-    - name: Install dependencies
-      run: sudo apt-get install libx11-dev zlib1g-dev libpng-dev libxtst-dev
     - name: Build it
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -74,10 +72,6 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '16'
-    - name: latest node-gyp for robotjs
-      run: |
-        npm install --global node-gyp@8.4.0
-        npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
     - name: Build it
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "generateUpdatesFilesForAllChannels": true,
     "afterPack": "./linux-sandbox-fix.js",
     "afterSign": "./notarize.js",
-    "buildDependenciesFromSource": true,
     "files": [
       "build",
       "resources",


### PR DESCRIPTION
This reverts commit 24140c427aa73b5f31c0a61be2af40d7f31594ef.

With prebuildify upstream the rebuild is no longer necessary
