### PR TITLE
Merge upstream release v2022.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,14 @@ To fix this, install libfuse2 as follows:
 sudo apt install libfuse2
 ```
 
+Under wayland, experimental native wayland support can be enabled with the command-line switch `--ozone-platform-hint` set to `auto`:
+
+```
+./jitsi-meet-x86_64.AppImage --ozone-platform-hint=auto
+```
+
+Note that screensharing is currently not supported under wayland, eg. the permissions prompt may loop endlessly.
+
 In case you experience a blank page after jitsi server upgrades, try removing the local cache files:
 
 ```

--- a/app/i18n/index.js
+++ b/app/i18n/index.js
@@ -8,6 +8,7 @@ const languages = {
     es: { translation: require('./lang/es.json') },
     fr: { translation: require('./lang/fr.json') },
     gl: { translation: require('./lang/gl.json') },
+    hr: { translation: require('./lang/hr.json') },
     hu: { translation: require('./lang/hu.json') },
     it: { translation: require('./lang/it.json') },
     nl: { translation: require('./lang/nl.json') },

--- a/app/i18n/lang/hr.json
+++ b/app/i18n/lang/hr.json
@@ -1,0 +1,33 @@
+{
+	"enterConferenceNameOrUrl": "Upiši ime sobe za tvoju konferenciju ili Jitsi URL",
+	"go": "KRENI",
+	"help": "Pomoć",
+	"termsLink": "Uvjeti",
+	"privacyLink": "Privatnost",
+	"recentListLabel": "ili se ponovo pridruži jednoj od tvojih nedavnih konferencijskih soba",
+	"sendFeedbackLink": "Pošalji povratnu informaciju",
+	"aboutLink": "Informacije o",
+	"sourceLink": "Izvroni kod",
+	"versionLabel": "Verzija: {{version}}",
+	"onboarding": {
+		"startTour": "Započni obilazak",
+		"skip": "Preskoči",
+		"welcome": "Pozdrav u {{appName}}",
+		"letUsShowYouAround": "Upoznaj se s radom aplikacije!",
+		"next": "Dalje",
+		"conferenceUrl": "Upiši ime (ili potpuni URL) sobe kojoj se želiš pridružiti. Izmisli si ime, ali obavijesti druge kako bi ga upisali.",
+		"settingsDrawerButton": "Pritisni ovdje za otvaranje postavki.",
+		"serverSetting": "Ovo će biti poslužitelj na kojem će se održavati tvoje konferencije. Možeš koristiti vlastiti poslužitelj, ali ne moraš!",
+		"serverTimeout": "Vremensko ograničenje za pridruživanje sastanku. Ako se sastanku nitko ne pridruži prije tog vremena, sastanak se otkazuje.",
+		"alwaysOnTop": "Ovdje se može uključiti postavljanje prozora „Uvijek ispred ostalih”, koji se prikazuje kada glavni prozor nije aktivan prozor. Ovo će se primijeniti na sve konferencije."
+	},
+	"settings": {
+		"back": "Natrag",
+		"alwaysOnTopWindow": "Uvijek ispred ostalih",
+		"invalidServer": "Neispravna URL-adresa poslužitelja",
+		"invalidServerTimeout": "Neispravna vrijednost za vremensko ograničenje poslužitelja",
+		"serverUrl": "URL-adresa poslužitelja",
+		"serverTimeout": "Vremensko ograničenje poslužitelja (u sekundama)",
+		"disableAGC": "Isključi kontrolu za automasko pojačanje zvuka"
+	}
+}

--- a/main.js
+++ b/main.js
@@ -40,9 +40,9 @@ app.commandLine.appendSwitch('disable-features', 'IOSurfaceCapturer');
 // Enable Opus RED field trial.
 app.commandLine.appendSwitch('force-fieldtrials', 'WebRTC-Audio-Red-For-Opus/Enabled/');
 
-// Enable optional PipeWire support.
+// Wayland: Enable optional PipeWire and window decorations support.
 if (!app.commandLine.hasSwitch('enable-features')) {
-    app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer');
+    app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer,WaylandWindowDecorations');
 }
 
 autoUpdater.logger = require('electron-log');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "ffmuc-meet",
-  "version": "2022.7.1",
+  "version": "2022.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "jitsi-meet-electron",
-      "version": "2022.7.1",
+      "name": "ffmuc-meet",
+      "version": "2022.8.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jitsi/electron-sdk": "^3.0.9",
+        "@jitsi/electron-sdk": "^3.0.15",
         "electron-debug": "^3.2.0",
         "electron-reload": "^1.5.0"
       },
@@ -39,7 +39,7 @@
         "babel-loader": "^8.2.3",
         "concurrently": "5.1.0",
         "css-loader": "^6.7.1",
-        "electron": "19.0.8",
+        "electron": "19.0.12",
         "electron-builder": "23.1.0",
         "electron-context-menu": "^2.5.0",
         "electron-is-dev": "^1.2.0",
@@ -3057,16 +3057,16 @@
       "dev": true
     },
     "node_modules/@jitsi/electron-sdk": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@jitsi/electron-sdk/-/electron-sdk-3.0.9.tgz",
-      "integrity": "sha512-y8n+1AiMaW3G4PphsD1gfZsGURpROxw1uTrvQ+3I19BXrtq0drxs6OYDo7Hww40YuLnUh5odVf5hwm+mhm2SCg==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@jitsi/electron-sdk/-/electron-sdk-3.0.15.tgz",
+      "integrity": "sha512-oElArTC7GD53jlq3+Y+2JSVez/e3QMWjrnqIKz7WH0oy6sfkff2zKqgEQRROz0bApJZGkOt5QKdZibc+ESCqkA==",
       "hasInstallScript": true,
       "dependencies": {
         "@jitsi/logger": "^2.0.0",
         "@jitsi/robotjs": "^0.6.9",
         "electron-store": "^8.0.1",
         "node-addon-api": "^5.0.0",
-        "node-gyp-build": "^4.5.0",
+        "node-gyp-build": "4.3.0",
         "postis": "^2.2.0"
       }
     },
@@ -3074,6 +3074,16 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",
       "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA=="
+    },
+    "node_modules/@jitsi/electron-sdk/node_modules/node-gyp-build": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/@jitsi/js-utils": {
       "version": "2.0.0",
@@ -6370,9 +6380,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "19.0.8",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.8.tgz",
-      "integrity": "sha512-OWK3P/NbDFfBUv+wbYv1/OV4jehY5DQPT7n1maQJfN9hsnrWTMktXS/bmS05eSUAjNAzHmKPKfiKH2c1Yr7nGw==",
+      "version": "19.0.12",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.12.tgz",
+      "integrity": "sha512-GOvG0t2NCeJYIfmC3g/dnEAQ71k3nQDbRVqQhpi2YbsYMury0asGJwqnVAv2uZQEwCwSx4XOwOQARTFEG/msWw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -17199,15 +17209,15 @@
       "dev": true
     },
     "@jitsi/electron-sdk": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@jitsi/electron-sdk/-/electron-sdk-3.0.9.tgz",
-      "integrity": "sha512-y8n+1AiMaW3G4PphsD1gfZsGURpROxw1uTrvQ+3I19BXrtq0drxs6OYDo7Hww40YuLnUh5odVf5hwm+mhm2SCg==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@jitsi/electron-sdk/-/electron-sdk-3.0.15.tgz",
+      "integrity": "sha512-oElArTC7GD53jlq3+Y+2JSVez/e3QMWjrnqIKz7WH0oy6sfkff2zKqgEQRROz0bApJZGkOt5QKdZibc+ESCqkA==",
       "requires": {
         "@jitsi/logger": "^2.0.0",
         "@jitsi/robotjs": "^0.6.9",
         "electron-store": "^8.0.1",
         "node-addon-api": "^5.0.0",
-        "node-gyp-build": "^4.5.0",
+        "node-gyp-build": "4.3.0",
         "postis": "^2.2.0"
       },
       "dependencies": {
@@ -17215,6 +17225,11 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",
           "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA=="
+        },
+        "node-gyp-build": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+          "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
         }
       }
     },
@@ -19750,9 +19765,9 @@
       }
     },
     "electron": {
-      "version": "19.0.8",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.8.tgz",
-      "integrity": "sha512-OWK3P/NbDFfBUv+wbYv1/OV4jehY5DQPT7n1maQJfN9hsnrWTMktXS/bmS05eSUAjNAzHmKPKfiKH2c1Yr7nGw==",
+      "version": "19.0.12",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.12.tgz",
+      "integrity": "sha512-GOvG0t2NCeJYIfmC3g/dnEAQ71k3nQDbRVqQhpi2YbsYMury0asGJwqnVAv2uZQEwCwSx4XOwOQARTFEG/msWw==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffmuc-meet",
-  "version": "2022.7.1",
+  "version": "2022.8.1",
   "description": "Electron application for Freifunk Meet",
   "main": "./build/main.js",
   "productName": "FreifunkMeet",
@@ -126,7 +126,7 @@
   "readmeFilename": "README.md",
   "license": "Apache-2.0",
   "dependencies": {
-    "@jitsi/electron-sdk": "^3.0.9",
+    "@jitsi/electron-sdk": "^3.0.15",
     "electron-debug": "^3.2.0",
     "electron-reload": "^1.5.0"
   },
@@ -155,7 +155,7 @@
     "babel-loader": "^8.2.3",
     "concurrently": "5.1.0",
     "css-loader": "^6.7.1",
-    "electron": "19.0.8",
+    "electron": "19.0.12",
     "electron-builder": "23.1.0",
     "electron-context-menu": "^2.5.0",
     "electron-is-dev": "^1.2.0",


### PR DESCRIPTION
As usual to get this into release v2022.8.1 with the github actions CI:

- Draft a release 2022.8.1 with tag version v2022.8.1 now (the "v" prefix in the tag version is important, the release name can be anything)
- Merge this PR (which contains the version bump to 2022.8.1 in the package.json)
- See the github action running after the merge on the main branch, attaching the artifacts to the draft release 2022.8.1
- Download the artifacts and test them, if successful, publish the draft release 2022.8.1