### PR TITLE
Update token to get permissions also for the winget-pkgs repo

### DIFF
--- a/.github/workflows/winget-releaser.yml
+++ b/.github/workflows/winget-releaser.yml
@@ -13,6 +13,10 @@ jobs:
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            jitsi-meet-electron
+            winget-pkgs
 
       - uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:


### PR DESCRIPTION
Maybe this helps.
Update token to get permissions also for the winget-pkgs repo

```
Inputs 'owner' and 'repositories' are not set. Creating token for this repository (freifunkMUC/jitsi-meet-electron).
```
```
Error: 
   0: Resource not accessible by integration
   1: failed to create branch freifunkMUC.FreifunkMeet-2026.1.1-73BBD332E9254DF3AD2AE043BE2AD55B
```

https://github.com/freifunkMUC/jitsi-meet-electron/actions/runs/22277801895


Unfortunately, there's no good way to test that.